### PR TITLE
deps(workflows): bump create-pull-request to v7

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -60,7 +60,7 @@ jobs:
           echo "RELEASE_DATE=$(date --rfc-3339=date)" >> ${GITHUB_ENV}
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.PAT }}
           commit-message: Sync repo to contain VIA Firmware as of ${{ env.RELEASE_DATE }}


### PR DESCRIPTION
Bumps the `create-pull-request` action to v7 in order to support `actions/checkout@v6` (see [release notes](https://github.com/peter-evans/create-pull-request/releases/tag/v7.0.9) for more info).

Based on [past release notes](https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md) from v3 to v7, there may be additional changes required – specifically, since the action no longer leaves the repo on the specified branch after completion [as of v5](https://github.com/peter-evans/create-pull-request/blob/main/docs/updating.md#behaviour-changes-2), this may create issues with the package and upload firmware artifacts steps. Further testing may be required.